### PR TITLE
Update platform.template.yaml

### DIFF
--- a/platform.template.yaml
+++ b/platform.template.yaml
@@ -50,7 +50,7 @@ info:
 # this key also gets mapped to the appropriate location in project.settings so
 # that the current UI can have its own workflow overridden as well.
 initialize:
-  repository: git://github.com/droptica/droopler_project.git@release/platformsh
+  repository: https://github.com/droptica/droopler_project.git@release/platformsh
   config: null
   files: []
   profile: droopler_project


### PR DESCRIPTION
from: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

On the Git protocol side, unencrypted git:// offers no integrity or authentication, making it subject to tampering. We expect very few people are still using this protocol, especially given that you can’t push (it’s read-only on GitHub). We’ll be disabling support for this protocol.